### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,6 +262,9 @@ exports.extract = function (cwd, opts) {
       if (win32) return next() // skip links on win for now before it can be tested
       xfs.unlink(name, function () {
         var srcpath = path.resolve(cwd, header.linkname)
+        if (!srcpath.startsWith(cwd)) {
+          return next(new Error('Invalid linkname: ' + header.linkname))
+        }
 
         xfs.link(srcpath, name, function (err) {
           if (err && err.code === 'EPERM' && opts.hardlinkAsFilesFallback) {


### PR DESCRIPTION
Potential fix for [https://github.com/mimz-devops/code-scanning-javascript-demo/security/code-scanning/1](https://github.com/mimz-devops/code-scanning-javascript-demo/security/code-scanning/1)

To fix the issue, we need to validate `header.linkname` to ensure it does not contain directory traversal elements (`..`) or other malicious constructs before using it to construct `srcpath`. The best approach is to use a validation function that checks whether the resolved path remains within the intended root directory (`cwd`). This ensures that even if `header.linkname` contains malicious elements, they cannot escape the intended directory.

The fix involves:
1. Adding a validation step for `header.linkname` before constructing `srcpath`.
2. Using `path.resolve` to normalize the path and ensure it is within the `cwd` directory.
3. Rejecting or skipping entries with invalid paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
